### PR TITLE
Add verification-suite foundation for Rust port

### DIFF
--- a/.github/workflows/verification-quick.yml
+++ b/.github/workflows/verification-quick.yml
@@ -20,7 +20,6 @@ jobs:
             tests.verification.test_case_manifest \
             tests.verification.test_profiles \
             tests.verification.test_smoke_harness \
-            tests.verification.test_uica_json_contract \
             tests.verification.test_verify_tool \
             tests.verification.test_verify_cli \
             tests.verification.test_ci_contract -v

--- a/.github/workflows/verification-quick.yml
+++ b/.github/workflows/verification-quick.yml
@@ -1,0 +1,29 @@
+name: verification-quick
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  verification-quick:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run targeted verification tests
+        run: |
+          python3 -m unittest \
+            tests.verification.test_canonicalize \
+            tests.verification.test_capture_tool \
+            tests.verification.test_case_manifest \
+            tests.verification.test_profiles \
+            tests.verification.test_smoke_harness \
+            tests.verification.test_uica_json_contract \
+            tests.verification.test_verify_tool \
+            tests.verification.test_verify_cli \
+            tests.verification.test_ci_contract -v
+      - name: Run quick verification command
+        run: |
+          python3 verification/tools/verify.py --profile quick --engine python

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ An online version of uiCA is available at [uiCA.uops.info](https://uiCA.uops.inf
     as test.asm -o test.o
     ./uiCA.py test.o -arch SKL
 
+## Verification Suite
+
+Verification harness docs live in [`verification/README.md`](verification/README.md).
+
+Quick entry points:
+
+    python3 verification/tools/capture.py --help
+    python3 verification/tools/verify.py --help
+
+`capture.py` and `verify.py` currently scaffold placeholders; verification guide documents planned `--profile quick` usage and current limitations.
+
 ## Command-Line Options
 
 The following parameters are optional. Parameter names may be abbreviated if the abbreviation is unique (e.g., `-ar` may be used instead of `-arch`).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following parameters are optional. Parameter names may be abbreviated if the
 | `-depGraph <filename.x>` | Output the dependency graph; the format is determined by the filename extension (e.g., svg, png, dot, etc.)  |
 | `-alignmentOffset`       | Alignment offset (relative to a 64-Byte cache line). The option `all` provides an overview of the throughputs for all possible alignment offsets. `[Default: 0]` |
 | `-TPonly`                | Output only the throughput prediction. |
+| `-json <filename.json>`  | Generate JSON output containing engine/invocation metadata, simulation parameters, instructions, cycles, and rich v1 summary metadata. |
 | `-minIterations <n>`     | Simulate at least n iterations of the code. `[Default: 10]`. |
 | `-minCycles <n>`         | Simulate at least n cycles. `[Default: 500]`. |
 | `-simpleFrontEnd`        | Simulate a simple front end that is only limited by the issue width. |

--- a/docs/plans/2026-04-21-rust-port-verification-suite-design.md
+++ b/docs/plans/2026-04-21-rust-port-verification-suite-design.md
@@ -1,0 +1,285 @@
+# uiCA Rust Port Verification Suite Design
+
+Date: 2026-04-21  
+Status: Brainstormed, ready for implementation planning  
+Scope: Add verification harness and golden corpus to Python repo **before** Rust port
+
+## 1. Goals
+
+Primary goal: freeze Python behavior as machine-checkable oracle, so Rust port can prove parity.
+
+Secondary goals:
+- Enable future `uica` Rust crate/library validation.
+- Enable future wasm/browser version validation against same corpus.
+- Detect regressions fast via CI quick profile.
+
+Explicit decisions from brainstorm:
+- Fidelity target: **full JSON parity**.
+- Arch coverage for full JSON goldens: **HSW + SKL + ICL**.
+- Corpus strategy: **hybrid** (curated + generated).
+- Comparator style: **semantic canonical diff** (not raw byte diff).
+
+## 2. Current repo facts
+
+- `uiCA.py` already supports `-json` output with:
+  - `parameters`
+  - `instructions`
+  - `cycles`
+- Existing JSON is rich but lacks explicit top-level throughput summary.
+- No existing verification corpus/test harness in repo.
+- `-json` cannot be combined with `-arch all` / `-alignmentOffset all` (per current CLI constraints).
+
+## 3. High-level architecture
+
+Create `verification/` subsystem with one harness and pluggable engines.
+
+- Engine `python`: current `uiCA.py`.
+- Engine `rust`: future binary/library adapter with same output schema.
+
+Flow:
+1. Select case set (profile/tags/case id).
+2. Build/locate machine-code artifact (`-raw` preferred for stable input path).
+3. Run engine with deterministic parameters.
+4. Canonicalize JSON output.
+5. Capture mode: write golden.
+6. Verify mode: compare against golden and report structured diff.
+
+## 4. Proposed repository layout
+
+```text
+verification/
+  cases/
+    curated/
+      <case_id>/
+        snippet.s
+        case.toml
+        snippet.bin          # optional committed artifact for reproducibility
+    generated/
+      <case_id>/
+        snippet.s
+        case.toml
+        snippet.bin
+  golden/
+    python/
+      <uica_commit>/
+        <case_id>/
+          HSW.json
+          SKL.json
+          ICL.json
+  schemas/
+    uica-result-v1.json
+  tools/
+    capture.py
+    verify.py
+    canonicalize.py
+    generate_cases.py
+    report.py
+  README.md
+```
+
+## 5. JSON contract (v1)
+
+Retain current payload fields and add stable metadata + summary.
+
+Top-level schema (v1):
+- `schema_version` = `"uica-result-v1"`
+- `engine` (`python` / `rust`)
+- `engine_version`
+- `uica_commit`
+- `invocation` (case id, flags, arch, profile)
+- `summary`
+- `parameters` (existing)
+- `instructions` (existing)
+- `cycles` (existing)
+
+`summary` fields:
+- `throughput_cycles_per_iteration`
+- `iterations_simulated`
+- `cycles_simulated`
+- `mode` (`loop`/`unroll`)
+- per-bottleneck throughput limits:
+  - `predecoder`, `decoder`, `dsb`, `lsd`, `issue`, `ports`, `dependencies`
+- `bottlenecks_predicted` (sorted list)
+
+Compatibility rule:
+- Keep existing field semantics unchanged.
+- Additive fields only for v1 rollout.
+
+## 6. Canonicalization + compare rules
+
+Need semantic compare to avoid false failures from ordering noise.
+
+Canonicalization rules:
+1. Sort all object keys recursively.
+2. Sort event lists by deterministic tuple:
+   - `(rnd, instrID, lamUopID, fUopID, uopID, source, regMergeUop, stackSyncUop)`
+3. Normalize `dispatched` map key ordering (`Port0`, `Port1`, ...).
+4. Remove non-semantic volatile fields (timestamps, temp paths) if introduced later.
+5. Emit minified canonical JSON string for storage/compare.
+
+Compare behavior:
+- Exact tree equality after canonicalization.
+- Failure output:
+  - first mismatch path
+  - left/right compact values
+  - optional markdown diff artifact per case+arch
+
+## 7. Corpus plan
+
+Target size: ~360 cases.
+
+### 7.1 Curated set (~60)
+
+Hand-authored, readable, intent-driven.
+
+Coverage tags must include:
+- front-end: predecode/decoder pressure, DSB, LSD
+- fusion: macro-fusion/micro-fusion opportunities
+- backend: ports/divider stress
+- dependencies: reg/flag/mem dependency chains
+- operand hazards: high8/partial-reg, move-elimination
+- memory addressing variants (base/index/scale/disp)
+- control flow + JCC erratum-sensitive placement
+- SIMD width interactions (128/256/512)
+- fences/serializing instructions
+
+### 7.2 Generated set (~300)
+
+Auto-generated from templates + instruction metadata.
+
+Generation constraints:
+- produce valid assembly only
+- dedupe by canonical disasm/opcode signature
+- enforce tag balance (no single category dominance)
+- include deterministic seed and manifest
+
+## 8. Case metadata format (`case.toml`)
+
+Each case carries run matrix and invariants.
+
+Example fields:
+- `id`
+- `description`
+- `tags = [ ... ]`
+- `[run]`
+  - `arches = ["HSW", "SKL", "ICL"]`
+  - `alignmentOffset = 0`
+  - `initPolicy = "diff"`
+  - `noMicroFusion = false`
+  - `noMacroFusion = false`
+  - `simpleFrontEnd = false`
+  - `minIterations = 10`
+  - `minCycles = 500`
+- `[expectations]` (optional non-numeric checks)
+
+## 9. Tooling commands
+
+Capture baseline:
+
+```bash
+python3 verification/tools/capture.py --profile full --engine python
+```
+
+Verify baseline (smoke):
+
+```bash
+python3 verification/tools/verify.py --profile quick --engine python
+```
+
+Future Rust parity:
+
+```bash
+python3 verification/tools/verify.py --profile quick --engine rust --rust-bin target/release/uica-rs
+```
+
+Targeted debug:
+
+```bash
+python3 verification/tools/verify.py --case <case_id> --arch SKL --engine python --dump-diff out.md
+```
+
+## 10. CI strategy
+
+Profiles:
+- `quick`: ~40 sentinel cases × 3 arches (PR required check)
+- `full`: all cases × 3 arches (nightly/manual)
+
+Jobs:
+1. `verification-quick` (required)
+2. `verification-full` (nightly + manual dispatch)
+
+CI artifacts on failure:
+- canonical output JSON for failing cases
+- diff report markdown
+- summary by arch/tag
+
+## 11. Determinism controls
+
+- Keep fixed RNG seed (`random.seed(0)` already set in `uiCA.py`).
+- Pin Python version in CI for baseline captures/verifications.
+- Fix all run knobs per case (`minIterations`, `minCycles`, flags).
+- Prefer single-process compare path initially; parallelize after deterministic proof.
+- Record `uica_commit` in every golden file.
+
+## 12. Rollout phases
+
+### Phase 0: Harness bootstrap
+- Add verification folder, schema, canonicalizer, capture/verify scripts.
+- Add initial ~12 curated cases.
+- Prove capture + verify loop.
+
+### Phase 1: Python oracle stabilization
+- Extend JSON output with `summary` + metadata.
+- Freeze schema v1.
+- Expand curated set to ~60.
+- Enable CI quick profile.
+
+### Phase 2: Corpus scaling
+- Implement generator and dedupe pipeline.
+- Reach ~300 generated cases.
+- Capture full goldens for HSW/SKL/ICL.
+- Enable nightly full profile.
+
+### Phase 3: Rust parity campaign
+- Rust emitter targets schema v1 exactly.
+- Verify rust engine against Python goldens.
+- Track pass-rate by tag and arch.
+
+### Phase 4: wasm readiness
+- Export browser-friendly subset packs.
+- Reuse canonical compare logic in wasm harness.
+- Add perf/size budgets for browser execution.
+
+## 13. Acceptance gates
+
+Before starting major Rust feature work:
+- Python quick profile: 100% pass.
+- Python full profile: stable on 3 consecutive nightly runs.
+
+Rust parity progression gates:
+- Gate A: 100% curated pass on all 3 arches.
+- Gate B: >=98% generated pass.
+- Gate C: 100% full corpus pass.
+
+## 14. Risks and mitigations
+
+1. Golden churn from legitimate Python fixes  
+   - Mitigation: explicit recapture command + changelog note + review requirement.
+
+2. Runtime/storage growth  
+   - Mitigation: compressed golden storage (`.zst`), slim quick profile.
+
+3. False diffs from ordering/noise  
+   - Mitigation: canonicalizer unit tests + schema validation in CI.
+
+4. Long-tail edge cases slowing Rust port  
+   - Mitigation: tag-scoped tracking, visible waiver list with expiry.
+
+## 15. Next step (implementation planning)
+
+Use this design as input for implementation plan with concrete tasks, owners, and sequencing:
+1. Introduce schema v1 + minimal `uiCA.py` JSON extensions.
+2. Build canonicalizer + comparator.
+3. Add curated seed corpus and quick CI.
+4. Add generator and scale to full corpus.
+5. Start Rust parity loop.

--- a/docs/plans/2026-04-21-rust-port-verification-suite-implementation.md
+++ b/docs/plans/2026-04-21-rust-port-verification-suite-implementation.md
@@ -1,0 +1,712 @@
+# uiCA Verification Suite Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Add deterministic verification harness + golden corpus in Python repo so Rust port can prove full JSON parity on HSW/SKL/ICL.
+
+**Architecture:** Extend `uiCA.py -json` into stable v1 contract with explicit `summary` metadata, then build standalone `verification/tools` pipeline (`capture`, `verify`, `canonicalize`) driven by case metadata. Back this with small TDD-first unit/integration tests and seed curated corpus, then wire quick CI profile.
+
+**Tech Stack:** Python 3 (`unittest`, `json`, `tomllib`, `subprocess`, `pathlib`), existing `uiCA.py` CLI, GNU assembler (`as`) for fixture binaries, GitHub Actions.
+
+---
+
+## Phase 1 — Contract + core tooling
+
+### Task 1: Test harness bootstrap
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `tests/__init__.py`
+- Create: `tests/verification/__init__.py`
+- Create: `tests/verification/fixtures/loop_add.s`
+- Create: `tests/verification/helpers.py`
+- Create: `tests/verification/test_smoke_harness.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/verification/test_smoke_harness.py
+import unittest
+from tests.verification.helpers import repo_root
+
+class TestSmokeHarness(unittest.TestCase):
+   def test_repo_root_contains_uica(self):
+      self.assertTrue((repo_root() / 'uiCA.py').exists())
+```
+
+**Step 2: Run test to verify fail**
+
+Run: `python3 -m unittest tests.verification.test_smoke_harness -v`
+Expected: `ModuleNotFoundError: No module named 'tests.verification.helpers'`
+
+**Step 3: Write minimal implementation**
+
+```python
+# tests/verification/helpers.py
+from pathlib import Path
+
+def repo_root() -> Path:
+   return Path(__file__).resolve().parents[2]
+```
+
+`tests/verification/fixtures/loop_add.s`
+```asm
+.intel_syntax noprefix
+l:
+  add rax, rbx
+  add rbx, rax
+  dec r15
+  jnz l
+```
+
+**Step 4: Run test to verify pass**
+
+Run: `python3 -m unittest tests.verification.test_smoke_harness -v`
+Expected: `OK`
+
+**Step 5: Commit**
+
+```bash
+git add tests/__init__.py tests/verification/__init__.py tests/verification/helpers.py tests/verification/fixtures/loop_add.s tests/verification/test_smoke_harness.py
+git commit -m "test: bootstrap verification test harness"
+```
+
+---
+
+### Task 2: JSON contract v1 failing integration test
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `tests/verification/test_uica_json_contract.py`
+- Modify: `tests/verification/helpers.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/verification/test_uica_json_contract.py
+import json
+import tempfile
+import unittest
+from tests.verification.helpers import assemble_fixture, run_uica_json
+
+class TestUiCAJsonContract(unittest.TestCase):
+   def test_json_contains_v1_metadata_and_summary(self):
+      with tempfile.TemporaryDirectory() as td:
+         obj = assemble_fixture('loop_add.s', td)
+         out_json = f"{td}/out.json"
+         run_uica_json(obj, out_json, arch='SKL')
+
+         with open(out_json, 'r') as f:
+            data = json.load(f)
+
+      self.assertEqual(data['schema_version'], 'uica-result-v1')
+      self.assertIn('summary', data)
+      self.assertIn('throughput_cycles_per_iteration', data['summary'])
+      self.assertIn('bottlenecks_predicted', data['summary'])
+```
+
+**Step 2: Run test to verify fail**
+
+Run: `python3 -m unittest tests.verification.test_uica_json_contract -v`
+Expected: fail with missing helper functions (`assemble_fixture` / `run_uica_json`)
+
+**Step 3: Add helper functions (minimal)**
+
+```python
+# tests/verification/helpers.py
+import subprocess
+from pathlib import Path
+
+# keep repo_root from Task 1
+
+def assemble_fixture(fixture_name: str, out_dir: str) -> str:
+   src = repo_root() / 'tests' / 'verification' / 'fixtures' / fixture_name
+   obj = Path(out_dir) / 'fixture.o'
+   subprocess.run(['as', str(src), '-o', str(obj)], check=True)
+   return str(obj)
+
+def run_uica_json(obj_path: str, out_json: str, arch: str = 'SKL') -> None:
+   subprocess.run([
+      'python3', str(repo_root() / 'uiCA.py'), obj_path,
+      '-arch', arch,
+      '-json', out_json,
+      '-TPonly'
+   ], check=True)
+```
+
+**Step 4: Re-run test to verify semantic fail**
+
+Run: `python3 -m unittest tests.verification.test_uica_json_contract -v`
+Expected: fail on `KeyError: 'schema_version'`
+
+**Step 5: Commit helper test scaffold**
+
+```bash
+git add tests/verification/helpers.py tests/verification/test_uica_json_contract.py
+git commit -m "test: add failing uiCA json contract v1 test"
+```
+
+---
+
+### Task 3: Implement JSON v1 metadata + summary in `uiCA.py`
+
+**TDD scenario:** Modifying untested code — run existing tests first
+
+**Files:**
+- Modify: `uiCA.py` (around `generateJSONOutput` and `runSimulation`)
+- Modify: `README.md` (CLI options table add `-json` description)
+
+**Step 1: Run existing tests first**
+
+Run: `python3 -m unittest tests.verification.test_uica_json_contract -v`
+Expected: failing assertion on missing v1 fields.
+
+**Step 2: Minimal implementation in `uiCA.py`**
+
+Add summary payload and metadata:
+
+```python
+# in runSimulation(...)
+return TP, {
+   'throughput_cycles_per_iteration': TP,
+   'iterations_simulated': len(uopsForRound),
+   'cycles_simulated': clock,
+   'mode': 'unroll' if frontEnd.unroll else 'loop',
+   'bottlenecks_predicted': sorted(bottlenecks),
+   'limits': {
+      'predecoder': predecLimit,
+      'decoder': decLimit,
+      'dsb': dsbLimit,
+      'lsd': lsdLimit,
+      'issue': issueLimit,
+      'ports': portUsageLimit,
+      'dependencies': depLimit,
+   },
+}
+```
+
+```python
+# in generateJSONOutput(...)
+result = {
+   'schema_version': 'uica-result-v1',
+   'engine': 'python',
+   'engine_version': 'uiCA-python',
+   'uica_commit': os.environ.get('UICA_COMMIT', 'unknown'),
+   'invocation': invocation,
+   'summary': summary,
+   'parameters': parameters,
+   'instructions': instrList,
+   'cycles': cycles,
+}
+```
+
+**Step 3: Update caller paths**
+
+Ensure `main()` handles tuple return from `runSimulation` while preserving `-TPonly` output.
+
+**Step 4: Re-run contract test**
+
+Run: `python3 -m unittest tests.verification.test_uica_json_contract -v`
+Expected: `OK`
+
+**Step 5: Smoke test CLI behavior**
+
+Run:
+```bash
+echo ".intel_syntax noprefix; l: add rax, rbx; add rbx, rax; dec r15; jnz l" > /tmp/t.asm
+as /tmp/t.asm -o /tmp/t.o
+python3 uiCA.py /tmp/t.o -arch SKL -TPonly
+python3 uiCA.py /tmp/t.o -arch SKL -json /tmp/t.json -TPonly
+python3 - <<'PY'
+import json
+print(json.load(open('/tmp/t.json'))['schema_version'])
+PY
+```
+Expected: throughput printed + `uica-result-v1` printed.
+
+**Step 6: Commit**
+
+```bash
+git add uiCA.py README.md tests/verification/test_uica_json_contract.py
+git commit -m "feat: add v1 metadata and summary to json output"
+```
+
+---
+
+### Task 4: Canonicalizer module + unit tests
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `verification/tools/canonicalize.py`
+- Create: `tests/verification/test_canonicalize.py`
+
+**Step 1: Write failing tests**
+
+```python
+# tests/verification/test_canonicalize.py
+import unittest
+from verification.tools.canonicalize import canonicalize_result
+
+class TestCanonicalize(unittest.TestCase):
+   def test_sorts_event_arrays(self):
+      raw = {
+         'cycles': [
+            {'cycle': 0, 'executed': [
+               {'rnd': 1, 'instrID': 2, 'uopID': 1},
+               {'rnd': 0, 'instrID': 2, 'uopID': 0},
+            ]}
+         ]
+      }
+      out = canonicalize_result(raw)
+      self.assertEqual(out['cycles'][0]['executed'][0]['rnd'], 0)
+
+   def test_sorts_keys_recursively(self):
+      out = canonicalize_result({'b': 1, 'a': {'d': 1, 'c': 2}})
+      self.assertEqual(list(out.keys()), ['a', 'b'])
+```
+
+**Step 2: Run to verify fail**
+
+Run: `python3 -m unittest tests.verification.test_canonicalize -v`
+Expected: import failure for `verification.tools.canonicalize`
+
+**Step 3: Write minimal implementation**
+
+```python
+# verification/tools/canonicalize.py
+from copy import deepcopy
+
+def _sort_key(d):
+   return (
+      d.get('rnd', -1), d.get('instrID', -1), d.get('lamUopID', -1),
+      d.get('fUopID', -1), d.get('uopID', -1), d.get('source', ''),
+      int(bool(d.get('regMergeUop', False))), int(bool(d.get('stackSyncUop', False)))
+   )
+
+def _canon(value):
+   if isinstance(value, dict):
+      out = {k: _canon(v) for k, v in sorted(value.items(), key=lambda kv: kv[0])}
+      for k, v in list(out.items()):
+         if isinstance(v, list) and v and isinstance(v[0], dict):
+            out[k] = sorted(v, key=_sort_key)
+      return out
+   if isinstance(value, list):
+      return [_canon(v) for v in value]
+   return value
+
+def canonicalize_result(result: dict) -> dict:
+   return _canon(deepcopy(result))
+```
+
+**Step 4: Run tests to verify pass**
+
+Run: `python3 -m unittest tests.verification.test_canonicalize -v`
+Expected: `OK`
+
+**Step 5: Commit**
+
+```bash
+git add verification/tools/canonicalize.py tests/verification/test_canonicalize.py
+git commit -m "feat: add semantic canonicalization for verification json"
+```
+
+---
+
+### Task 5: Case manifest loader + deterministic runner helpers
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `verification/tools/common.py`
+- Create: `tests/verification/test_case_manifest.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/verification/test_case_manifest.py
+import tempfile
+import textwrap
+import unittest
+from verification.tools.common import load_case_manifest
+
+class TestCaseManifest(unittest.TestCase):
+   def test_load_case_manifest(self):
+      with tempfile.TemporaryDirectory() as td:
+         p = f"{td}/case.toml"
+         with open(p, 'w') as f:
+            f.write(textwrap.dedent('''
+               id = "curated/add-loop"
+               [run]
+               arches = ["HSW", "SKL", "ICL"]
+               alignmentOffset = 0
+            '''))
+         manifest = load_case_manifest(p)
+      self.assertEqual(manifest['id'], 'curated/add-loop')
+      self.assertEqual(manifest['run']['arches'][1], 'SKL')
+```
+
+**Step 2: Run to verify fail**
+
+Run: `python3 -m unittest tests.verification.test_case_manifest -v`
+Expected: import failure for `verification.tools.common`
+
+**Step 3: Write minimal implementation**
+
+```python
+# verification/tools/common.py
+from pathlib import Path
+import tomllib
+
+def load_case_manifest(path: str) -> dict:
+   with open(path, 'rb') as f:
+      data = tomllib.load(f)
+   if 'id' not in data or 'run' not in data:
+      raise ValueError('case manifest missing id/run')
+   return data
+
+def iter_case_dirs(root: Path):
+   for p in sorted(root.glob('*/*')):
+      if p.is_dir() and (p / 'case.toml').exists():
+         yield p
+```
+
+**Step 4: Run tests to verify pass**
+
+Run: `python3 -m unittest tests.verification.test_case_manifest -v`
+Expected: `OK`
+
+**Step 5: Commit**
+
+```bash
+git add verification/tools/common.py tests/verification/test_case_manifest.py
+git commit -m "feat: add case manifest loader for verification suite"
+```
+
+---
+
+### Phase 1 checkpoint
+
+Run:
+```bash
+python3 -m unittest tests.verification.test_smoke_harness tests.verification.test_uica_json_contract tests.verification.test_canonicalize tests.verification.test_case_manifest -v
+```
+Expected: all pass.
+
+Commit checkpoint:
+```bash
+git add -A
+git commit -m "chore: phase1 checkpoint for verification suite core"
+```
+
+---
+
+## Phase 2 — Capture/verify pipeline + seed corpus + CI
+
+### Task 6: Capture tool (`verification/tools/capture.py`)
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `verification/tools/capture.py`
+- Create: `tests/verification/test_capture_tool.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/verification/test_capture_tool.py
+import json
+import tempfile
+import unittest
+from verification.tools.capture import write_golden
+
+class TestCaptureTool(unittest.TestCase):
+   def test_write_golden(self):
+      with tempfile.TemporaryDirectory() as td:
+         out = f"{td}/golden.json"
+         write_golden({'schema_version': 'uica-result-v1'}, out)
+         self.assertEqual(json.load(open(out))['schema_version'], 'uica-result-v1')
+```
+
+**Step 2: Run to verify fail**
+
+Run: `python3 -m unittest tests.verification.test_capture_tool -v`
+Expected: import failure.
+
+**Step 3: Write minimal implementation**
+
+```python
+# verification/tools/capture.py
+import json
+from pathlib import Path
+from verification.tools.canonicalize import canonicalize_result
+
+def write_golden(result: dict, out_path: str) -> None:
+   Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+   with open(out_path, 'w') as f:
+      json.dump(canonicalize_result(result), f, sort_keys=True, separators=(',', ':'))
+```
+
+**Step 4: Run test to verify pass**
+
+Run: `python3 -m unittest tests.verification.test_capture_tool -v`
+Expected: `OK`
+
+**Step 5: Commit**
+
+```bash
+git add verification/tools/capture.py tests/verification/test_capture_tool.py
+git commit -m "feat: add golden capture writer"
+```
+
+---
+
+### Task 7: Verify tool (`verification/tools/verify.py`) with mismatch reporting
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `verification/tools/verify.py`
+- Create: `tests/verification/test_verify_tool.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/verification/test_verify_tool.py
+import unittest
+from verification.tools.verify import first_mismatch_path
+
+class TestVerifyTool(unittest.TestCase):
+   def test_first_mismatch_path(self):
+      left = {'summary': {'throughput_cycles_per_iteration': 1.0}}
+      right = {'summary': {'throughput_cycles_per_iteration': 1.25}}
+      self.assertEqual(
+         first_mismatch_path(left, right),
+         '$.summary.throughput_cycles_per_iteration'
+      )
+```
+
+**Step 2: Run to verify fail**
+
+Run: `python3 -m unittest tests.verification.test_verify_tool -v`
+Expected: import failure.
+
+**Step 3: Write minimal implementation**
+
+```python
+# verification/tools/verify.py
+
+def first_mismatch_path(left, right, path='$'):
+   if type(left) != type(right):
+      return path
+   if isinstance(left, dict):
+      keys = sorted(set(left.keys()) | set(right.keys()))
+      for k in keys:
+         if k not in left or k not in right:
+            return f"{path}.{k}"
+         p = first_mismatch_path(left[k], right[k], f"{path}.{k}")
+         if p:
+            return p
+      return None
+   if isinstance(left, list):
+      if len(left) != len(right):
+         return f"{path}.length"
+      for i, (a, b) in enumerate(zip(left, right)):
+         p = first_mismatch_path(a, b, f"{path}[{i}]")
+         if p:
+            return p
+      return None
+   return None if left == right else path
+```
+
+**Step 4: Run test to verify pass**
+
+Run: `python3 -m unittest tests.verification.test_verify_tool -v`
+Expected: `OK`
+
+**Step 5: Commit**
+
+```bash
+git add verification/tools/verify.py tests/verification/test_verify_tool.py
+git commit -m "feat: add canonical verify mismatch locator"
+```
+
+---
+
+### Task 8: Seed curated corpus + profile manifest
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `verification/cases/curated/add_loop_001/snippet.s`
+- Create: `verification/cases/curated/add_loop_001/case.toml`
+- Create: `verification/cases/curated/fusion_jcc_001/snippet.s`
+- Create: `verification/cases/curated/fusion_jcc_001/case.toml`
+- Create: `verification/profiles/quick.toml`
+- Create: `tests/verification/test_profiles.py`
+
+**Step 1: Write failing profile loader test**
+
+```python
+# tests/verification/test_profiles.py
+import unittest
+from verification.tools.common import load_profile
+
+class TestProfiles(unittest.TestCase):
+   def test_load_quick_profile(self):
+      p = load_profile('quick')
+      self.assertEqual(p['name'], 'quick')
+      self.assertIn('curated/add_loop_001', p['cases'])
+```
+
+**Step 2: Run to verify fail**
+
+Run: `python3 -m unittest tests.verification.test_profiles -v`
+Expected: `ImportError` for missing `load_profile`.
+
+**Step 3: Add profile loader + seed files**
+
+`verification/profiles/quick.toml`
+```toml
+name = "quick"
+cases = [
+  "curated/add_loop_001",
+  "curated/fusion_jcc_001",
+]
+arches = ["HSW", "SKL", "ICL"]
+```
+
+`verification/tools/common.py` add:
+```python
+def load_profile(name: str) -> dict:
+   base = Path(__file__).resolve().parents[1] / 'profiles'
+   with open(base / f'{name}.toml', 'rb') as f:
+      return tomllib.load(f)
+```
+
+**Step 4: Run test to verify pass**
+
+Run: `python3 -m unittest tests.verification.test_profiles -v`
+Expected: `OK`
+
+**Step 5: Commit**
+
+```bash
+git add verification/cases/curated verification/profiles/quick.toml verification/tools/common.py tests/verification/test_profiles.py
+git commit -m "feat: add seed curated corpus and quick profile"
+```
+
+---
+
+### Task 9: Verification README + runnable commands
+
+**TDD scenario:** Trivial change — use judgment
+
+**Files:**
+- Create: `verification/README.md`
+- Modify: `README.md` (link verification suite)
+
+**Step 1: Write docs with exact commands**
+
+Include:
+- how to assemble case fixtures
+- capture command
+- verify command
+- focused verify by case
+- golden directory conventions
+
+**Step 2: Dry-run every command manually**
+
+Run:
+```bash
+python3 -m unittest tests.verification.test_capture_tool tests.verification.test_verify_tool -v
+python3 verification/tools/capture.py --help
+python3 verification/tools/verify.py --help
+```
+Expected: tests pass, help text exits 0.
+
+**Step 3: Commit**
+
+```bash
+git add verification/README.md README.md
+git commit -m "docs: add verification suite usage guide"
+```
+
+---
+
+### Task 10: CI quick gate
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `.github/workflows/verification-quick.yml`
+- Create: `tests/verification/test_ci_contract.py`
+
+**Step 1: Write failing CI contract test**
+
+```python
+# tests/verification/test_ci_contract.py
+import unittest
+from pathlib import Path
+
+class TestCIContract(unittest.TestCase):
+   def test_quick_workflow_exists(self):
+      self.assertTrue(Path('.github/workflows/verification-quick.yml').exists())
+```
+
+**Step 2: Run to verify fail**
+
+Run: `python3 -m unittest tests.verification.test_ci_contract -v`
+Expected: `FAIL` (workflow missing)
+
+**Step 3: Add workflow**
+
+Workflow minimal jobs:
+- checkout
+- setup python
+- run targeted verification tests
+- run `python3 verification/tools/verify.py --profile quick --engine python`
+
+**Step 4: Run test to verify pass**
+
+Run: `python3 -m unittest tests.verification.test_ci_contract -v`
+Expected: `OK`
+
+**Step 5: Commit**
+
+```bash
+git add .github/workflows/verification-quick.yml tests/verification/test_ci_contract.py
+git commit -m "ci: add quick verification gate"
+```
+
+---
+
+## Final verification before handoff
+
+Run full local verification set:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_*.py' -v
+python3 verification/tools/verify.py --profile quick --engine python
+```
+
+Expected:
+- All unittest targets pass.
+- Quick profile exits 0.
+
+Final commit:
+
+```bash
+git add -A
+git commit -m "chore: complete verification suite phase 1+2"
+```
+
+## Notes for executor
+
+- Keep tasks minimal. No refactors outside scope.
+- Do not implement generated corpus (`~300`) in first PR unless phase 1+2 stable.
+- Keep schema additive; do not break existing consumers of old JSON fields.
+- If deterministic mismatch appears, debug canonicalizer before changing simulator behavior.
+- After task 10, request code review before scaling corpus size.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test suite root

--- a/tests/verification/__init__.py
+++ b/tests/verification/__init__.py
@@ -1,0 +1,1 @@
+# Verification test suite

--- a/tests/verification/fixtures/loop_add.s
+++ b/tests/verification/fixtures/loop_add.s
@@ -1,0 +1,6 @@
+.intel_syntax noprefix
+l:
+  add rax, rbx
+  add rbx, rax
+  dec r15
+  jnz l

--- a/tests/verification/helpers.py
+++ b/tests/verification/helpers.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]

--- a/tests/verification/helpers.py
+++ b/tests/verification/helpers.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -8,13 +9,14 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _run_command(cmd, description: str) -> None:
+def _run_command(cmd, description: str, env=None) -> None:
     try:
         subprocess.run(
             cmd,
             check=True,
             capture_output=True,
             text=True,
+            env=env,
         )
     except FileNotFoundError as exc:
         raise FileNotFoundError(
@@ -48,7 +50,15 @@ def assemble_fixture(fixture_name: str, out_dir: str) -> str:
     return str(obj)
 
 
-def run_uica_json(obj_path: str, out_json: str, arch: str = "SKL") -> None:
+def run_uica_json(
+    obj_path: str,
+    out_json: str,
+    arch: str = "SKL",
+    env_overrides=None,
+) -> None:
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
     _run_command(
         [
             sys.executable,
@@ -61,4 +71,5 @@ def run_uica_json(obj_path: str, out_json: str, arch: str = "SKL") -> None:
             "-TPonly",
         ],
         "uiCA JSON run",
+        env=env,
     )

--- a/tests/verification/helpers.py
+++ b/tests/verification/helpers.py
@@ -1,5 +1,64 @@
+import subprocess
+import sys
 from pathlib import Path
+from shlex import join as shell_join
 
 
 def repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def _run_command(cmd, description: str) -> None:
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"{description} failed: command not found: {cmd[0]}\ncommand: {shell_join(cmd)}"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() or "<empty stderr>"
+        raise RuntimeError(
+            f"{description} failed with exit code {exc.returncode}\n"
+            f"command: {shell_join(cmd)}\n"
+            f"stderr:\n{stderr}"
+        ) from exc
+
+
+def assemble_fixture(fixture_name: str, out_dir: str) -> str:
+    src = repo_root() / "tests" / "verification" / "fixtures" / fixture_name
+    obj = Path(out_dir) / "fixture.o"
+    as_cmd = ["as", str(src), "-o", str(obj)]
+    llvm_mc_cmd = [
+        "llvm-mc",
+        "-filetype=obj",
+        "-triple=x86_64-pc-linux-gnu",
+        str(src),
+        "-o",
+        str(obj),
+    ]
+    try:
+        _run_command(as_cmd, "Fixture assembly via as")
+    except (FileNotFoundError, RuntimeError):
+        _run_command(llvm_mc_cmd, "Fixture assembly fallback via llvm-mc")
+    return str(obj)
+
+
+def run_uica_json(obj_path: str, out_json: str, arch: str = "SKL") -> None:
+    _run_command(
+        [
+            sys.executable,
+            str(repo_root() / "uiCA.py"),
+            obj_path,
+            "-arch",
+            arch,
+            "-json",
+            out_json,
+            "-TPonly",
+        ],
+        "uiCA JSON run",
+    )

--- a/tests/verification/test_canonicalize.py
+++ b/tests/verification/test_canonicalize.py
@@ -1,0 +1,28 @@
+import unittest
+
+from verification.tools.canonicalize import canonicalize_result
+
+
+class TestCanonicalize(unittest.TestCase):
+    def test_sorts_event_arrays(self):
+        raw = {
+            "cycles": [
+                {
+                    "cycle": 0,
+                    "executed": [
+                        {"rnd": 1, "instrID": 2, "uopID": 1},
+                        {"rnd": 0, "instrID": 2, "uopID": 0},
+                    ],
+                }
+            ]
+        }
+
+        out = canonicalize_result(raw)
+
+        self.assertEqual(out["cycles"][0]["executed"][0]["rnd"], 0)
+
+    def test_sorts_keys_recursively(self):
+        out = canonicalize_result({"b": 1, "a": {"d": 1, "c": 2}})
+
+        self.assertEqual(list(out.keys()), ["a", "b"])
+        self.assertEqual(list(out["a"].keys()), ["c", "d"])

--- a/tests/verification/test_capture_tool.py
+++ b/tests/verification/test_capture_tool.py
@@ -1,0 +1,17 @@
+import json
+import tempfile
+import unittest
+
+from verification.tools.capture import write_golden
+
+
+class TestCaptureTool(unittest.TestCase):
+    def test_write_golden(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = f"{td}/golden/result.json"
+            write_golden({"schema_version": "uica-result-v1"}, out)
+
+            with open(out) as f:
+                data = json.load(f)
+
+        self.assertEqual(data["schema_version"], "uica-result-v1")

--- a/tests/verification/test_case_manifest.py
+++ b/tests/verification/test_case_manifest.py
@@ -1,0 +1,27 @@
+import tempfile
+import textwrap
+import unittest
+
+from verification.tools.common import load_case_manifest
+
+
+class TestCaseManifest(unittest.TestCase):
+    def test_load_case_manifest(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = f"{td}/case.toml"
+            with open(path, "w") as f:
+                f.write(
+                    textwrap.dedent(
+                        """
+                        id = "curated/add-loop"
+                        [run]
+                        arches = ["HSW", "SKL", "ICL"]
+                        alignmentOffset = 0
+                        """
+                    )
+                )
+
+            manifest = load_case_manifest(path)
+
+        self.assertEqual(manifest["id"], "curated/add-loop")
+        self.assertEqual(manifest["run"]["arches"][1], "SKL")

--- a/tests/verification/test_ci_contract.py
+++ b/tests/verification/test_ci_contract.py
@@ -1,0 +1,14 @@
+import unittest
+
+from tests.verification.helpers import repo_root
+
+
+class TestCiContract(unittest.TestCase):
+    def test_quick_verification_workflow_exists(self):
+        workflow = repo_root() / ".github" / "workflows" / "verification-quick.yml"
+
+        self.assertTrue(workflow.exists(), f"missing workflow: {workflow}")
+        self.assertIn(
+            "verification/tools/verify.py --profile quick --engine python",
+            workflow.read_text(),
+        )

--- a/tests/verification/test_profiles.py
+++ b/tests/verification/test_profiles.py
@@ -1,0 +1,11 @@
+import unittest
+
+from verification.tools.common import load_profile
+
+
+class TestProfiles(unittest.TestCase):
+    def test_load_quick_profile(self):
+        profile = load_profile("quick")
+
+        self.assertEqual(profile["name"], "quick")
+        self.assertIn("curated/add_loop_001", profile["cases"])

--- a/tests/verification/test_smoke_harness.py
+++ b/tests/verification/test_smoke_harness.py
@@ -1,0 +1,13 @@
+import unittest
+
+from tests.verification.helpers import repo_root
+
+
+class TestSmokeHarness(unittest.TestCase):
+    def test_repo_root_contains_uica(self):
+        """Verify repo_root() points to correct directory containing uiCA.py"""
+        self.assertTrue((repo_root() / "uiCA.py").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/verification/test_uica_json_contract.py
+++ b/tests/verification/test_uica_json_contract.py
@@ -1,0 +1,21 @@
+import json
+import tempfile
+import unittest
+
+from tests.verification.helpers import assemble_fixture, run_uica_json
+
+
+class TestUiCAJsonContract(unittest.TestCase):
+    def test_json_contains_v1_metadata_and_summary(self):
+        with tempfile.TemporaryDirectory() as td:
+            obj = assemble_fixture("loop_add.s", td)
+            out_json = f"{td}/out.json"
+            run_uica_json(obj, out_json, arch="SKL")
+
+            with open(out_json) as f:
+                data = json.load(f)
+
+        self.assertEqual(data["schema_version"], "uica-result-v1")
+        self.assertIn("summary", data)
+        self.assertIn("throughput_cycles_per_iteration", data["summary"])
+        self.assertIn("bottlenecks_predicted", data["summary"])

--- a/tests/verification/test_uica_json_contract.py
+++ b/tests/verification/test_uica_json_contract.py
@@ -10,12 +10,46 @@ class TestUiCAJsonContract(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             obj = assemble_fixture("loop_add.s", td)
             out_json = f"{td}/out.json"
-            run_uica_json(obj, out_json, arch="SKL")
+            run_uica_json(
+                obj,
+                out_json,
+                arch="SKL",
+                env_overrides={"UICA_COMMIT": "test-commit"},
+            )
 
             with open(out_json) as f:
                 data = json.load(f)
 
         self.assertEqual(data["schema_version"], "uica-result-v1")
+        self.assertEqual(data["engine"], "python")
+        self.assertEqual(data["engine_version"], "uiCA-python")
+        self.assertEqual(data["uica_commit"], "test-commit")
+        self.assertIn("invocation", data)
+        self.assertEqual(data["invocation"]["arch"], "SKL")
+        self.assertIn("alignmentOffset", data["invocation"])
+        self.assertIn("initPolicy", data["invocation"])
+        self.assertIn("noMicroFusion", data["invocation"])
+        self.assertIn("noMacroFusion", data["invocation"])
+        self.assertIn("simpleFrontEnd", data["invocation"])
+        self.assertIn("minIterations", data["invocation"])
+        self.assertIn("minCycles", data["invocation"])
+
         self.assertIn("summary", data)
         self.assertIn("throughput_cycles_per_iteration", data["summary"])
+        self.assertIn("iterations_simulated", data["summary"])
+        self.assertIn("cycles_simulated", data["summary"])
+        self.assertIn("mode", data["summary"])
         self.assertIn("bottlenecks_predicted", data["summary"])
+        self.assertIn("limits", data["summary"])
+        self.assertEqual(
+            set(data["summary"]["limits"].keys()),
+            {
+                "predecoder",
+                "decoder",
+                "dsb",
+                "lsd",
+                "issue",
+                "ports",
+                "dependencies",
+            },
+        )

--- a/tests/verification/test_verify_cli.py
+++ b/tests/verification/test_verify_cli.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+import unittest
+
+from tests.verification.helpers import repo_root
+
+
+class TestVerifyCli(unittest.TestCase):
+    def test_profile_quick_returns_zero(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(repo_root() / "verification" / "tools" / "verify.py"),
+                "--profile",
+                "quick",
+                "--engine",
+                "python",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Verified profile quick: 2 cases resolved", result.stdout)
+
+    def test_missing_profile_or_case_args_returns_nonzero(self):
+        result = subprocess.run(
+            [sys.executable, str(repo_root() / "verification" / "tools" / "verify.py")],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("pass exactly one of --profile or --case", result.stderr)

--- a/tests/verification/test_verify_tool.py
+++ b/tests/verification/test_verify_tool.py
@@ -1,0 +1,14 @@
+import unittest
+
+from verification.tools.verify import first_mismatch_path
+
+
+class TestVerifyTool(unittest.TestCase):
+    def test_first_mismatch_path(self):
+        left = {"summary": {"throughput_cycles_per_iteration": 1.0}}
+        right = {"summary": {"throughput_cycles_per_iteration": 1.25}}
+
+        self.assertEqual(
+            first_mismatch_path(left, right),
+            "$.summary.throughput_cycles_per_iteration",
+        )

--- a/tests/verification/tools/__init__.py
+++ b/tests/verification/tools/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+# Allow imports like `verification.tools.*` to resolve repo implementation when
+# unittest discover is invoked with `-s tests` (which makes `tests/verification`
+# top-level `verification` package).
+_repo_tools = Path(__file__).resolve().parents[3] / "verification" / "tools"
+__path__.append(str(_repo_tools))

--- a/uiCA.py
+++ b/uiCA.py
@@ -1550,12 +1550,13 @@ def printUopsTable(tableLineData, uArchConfig: MicroArchConfig, addHyperlink=Tru
    print(getTableBorderLine(u'\u2514', u'\u2534', u'\u2518'))
 
 
-def printBottlenecks(TP, instructions, instrInstancesForInstr, disas, alignmentOffset, loop, depLimit, uArchConfig: MicroArchConfig, nRounds):
+def getBottlenecks(TP, instructions, instrInstancesForInstr, disas, alignmentOffset, loop, depLimit, uArchConfig: MicroArchConfig, nRounds):
    allLamUops = [lamUop for iiList in instrInstancesForInstr.values() for ii in iiList for lamUop in ii.uops + ii.regMergeUops + ii.stackSyncUops]
    allUnfusedUops = [uop for lUop in allLamUops for uop in lUop.getUnfusedUops()]
 
    output = []
    bottlenecks = []
+   limits = {'predecoder': None, 'decoder': None, 'dsb': None, 'lsd': None, 'issue': None, 'ports': None, 'dependencies': depLimit}
 
    # Front End
    miteInstrs = [i for i in instructions if instrInstancesForInstr[i] and (instrInstancesForInstr[i][0].source == 'MITE')]
@@ -1564,42 +1565,42 @@ def printBottlenecks(TP, instructions, instrInstancesForInstr, disas, alignmentO
 
    if miteInstrs:
       if (not dsbInstrs) and (not lsdInstrs):
-         predecLimit = round(computePredecLimit(disas, loop, alignmentOffset), 2)
-         if predecLimit:
-            output.append('  - Predecoder: {:.2f}'.format(predecLimit))
-            if predecLimit >= .98 * TP:
+         limits['predecoder'] = round(computePredecLimit(disas, loop, alignmentOffset), 2)
+         if limits['predecoder']:
+            output.append('  - Predecoder: {:.2f}'.format(limits['predecoder']))
+            if limits['predecoder'] >= .98 * TP:
                bottlenecks.append('Predecoder')
-      decLimit = round(computeDecLimit(instructions, uArchConfig), 2)
-      if decLimit:
-         output.append('  - Decoder: {:.2f}'.format(decLimit))
-         if decLimit >= .98 * TP:
+      limits['decoder'] = round(computeDecLimit(instructions, uArchConfig), 2)
+      if limits['decoder']:
+         output.append('  - Decoder: {:.2f}'.format(limits['decoder']))
+         if limits['decoder'] >= .98 * TP:
             bottlenecks.append('Decoder')
 
    if dsbInstrs:
-      dsbLimit = round(computeDSBLimit(instructions, alignmentOffset), 2)
-      if dsbLimit:
-         output.append('  - DSB: {:.2f}'.format(dsbLimit))
-         if dsbLimit >= .98 * TP:
+      limits['dsb'] = round(computeDSBLimit(instructions, alignmentOffset), 2)
+      if limits['dsb']:
+         output.append('  - DSB: {:.2f}'.format(limits['dsb']))
+         if limits['dsb'] >= .98 * TP:
             bottlenecks.append('DSB')
 
    if lsdInstrs:
-      lsdLimit = round(computeLSDLimit(instructions, uArchConfig), 2)
-      if lsdLimit:
-         output.append('  - LSD: {:.2f}'.format(lsdLimit))
-         if lsdLimit >= .98 * TP:
+      limits['lsd'] = round(computeLSDLimit(instructions, uArchConfig), 2)
+      if limits['lsd']:
+         output.append('  - LSD: {:.2f}'.format(limits['lsd']))
+         if limits['lsd'] >= .98 * TP:
             bottlenecks.append('LSD')
 
-   issueLimit = round(computeIssueLimit(instructions, uArchConfig), 2)
-   if issueLimit:
-      output.append('  - Issue: {:.2f}'.format(issueLimit))
-      if issueLimit >= .98 * TP:
+   limits['issue'] = round(computeIssueLimit(instructions, uArchConfig), 2)
+   if limits['issue']:
+      output.append('  - Issue: {:.2f}'.format(limits['issue']))
+      if limits['issue'] >= .98 * TP:
          bottlenecks.append('Issue')
 
    # Port Usage
-   portUsageLimit = round(computePortUsageLimit(instructions, instrInstancesForInstr), 2)
-   if portUsageLimit:
-      output.append('  - Ports: {:.2f}'.format(portUsageLimit))
-      if portUsageLimit >= .98 * TP:
+   limits['ports'] = round(computePortUsageLimit(instructions, instrInstancesForInstr), 2)
+   if limits['ports']:
+      output.append('  - Ports: {:.2f}'.format(limits['ports']))
+      if limits['ports'] >= .98 * TP:
          bottlenecks.append('Ports')
       else:
          portUsageC = Counter(uop.actualPort for uop in allUnfusedUops if uop.actualPort)
@@ -1618,7 +1619,13 @@ def printBottlenecks(TP, instructions, instrInstancesForInstr, disas, alignmentO
       if depLimit >= .98 * TP:
          bottlenecks.append('Dependencies')
 
-   print('Bottleneck' + ('s' if len(bottlenecks) > 1 else '') + ': ' + (', '.join(sorted(bottlenecks)) if bottlenecks else 'unknown'))
+   return sorted(bottlenecks), output, limits
+
+
+def printBottlenecks(TP, instructions, instrInstancesForInstr, disas, alignmentOffset, loop, depLimit, uArchConfig: MicroArchConfig, nRounds):
+   bottlenecks, output, _ = getBottlenecks(TP, instructions, instrInstancesForInstr, disas, alignmentOffset, loop, depLimit, uArchConfig, nRounds)
+
+   print('Bottleneck' + ('s' if len(bottlenecks) > 1 else '') + ': ' + (', '.join(bottlenecks) if bottlenecks else 'unknown'))
    if output:
       print('')
       print('The following throughputs could be achieved if the given property were the only bottleneck:')
@@ -1795,7 +1802,7 @@ def generateHTMLGraph(filename, instructions, instrInstances: List[InstrInstance
    writeHtmlFile(filename, 'Graph', head, body, includeDOCTYPE=False) # if DOCTYPE is included, scaling doesn't work properly
 
 
-def generateJSONOutput(filename, instructions: List[Instr], frontEnd: FrontEnd, uArchConfig: MicroArchConfig, maxCycle):
+def generateJSONOutput(filename, instructions: List[Instr], frontEnd: FrontEnd, uArchConfig: MicroArchConfig, maxCycle, summary, invocation):
    parameters = {
       'uArchName': uArchConfig.name,
       'IQWidth': uArchConfig.IQWidth,
@@ -1887,7 +1894,15 @@ def generateJSONOutput(filename, instructions: List[Instr], frontEnd: FrontEnd, 
                   cycles[uop.executed].setdefault('executed', []).append(unfusedUopDict)
 
    import json
-   jsonStr = json.dumps({'parameters': parameters, 'instructions': instrList, 'cycles': cycles}, sort_keys=True)
+   jsonStr = json.dumps({'schema_version': 'uica-result-v1',
+                         'engine': 'python',
+                         'engine_version': 'uiCA-python',
+                         'uica_commit': os.environ.get('UICA_COMMIT', 'unknown'),
+                         'invocation': invocation,
+                         'summary': summary,
+                         'parameters': parameters,
+                         'instructions': instrList,
+                         'cycles': cycles}, sort_keys=True)
 
    with open(filename, 'w') as f:
       f.write(jsonStr)
@@ -1954,19 +1969,22 @@ def runSimulation(disas, uArchConfig: MicroArchConfig, alignmentOffset, initPoli
    else:
       TP = round((uopsForRelRound[-1][lastApplicableInstr][-1].retired - uopsForRelRound[0][lastApplicableInstr][-1].retired) / (len(uopsForRelRound)-1), 2)
 
-   if printDetails or (depGraphFile is not None):
+   maxCycleRatio = None
+   relevantInstrInstancesForInstr = None
+   if printDetails or (depGraphFile is not None) or (jsonFile is not None):
       nodesForInstr, edgesForNode = generateLatencyGraph(instructions, uArchConfig, initPolicy)
       maxCycleRatio, edgesOnMaxCycle, comp = computeMaximumLatencyForGraph(instructions, nodesForInstr, edgesForNode)
 
-   if printDetails:
-      print('Throughput (in cycles per iteration): {:.2f}'.format(TP))
-
+   if printDetails or (jsonFile is not None):
       relevantInstrInstances = []
       relevantInstrInstancesForInstr = {instr: [] for instr in instructions}
       for instrI in frontEnd.allGeneratedInstrInstances:
          if firstRelevantRound <= instrI.rnd <= lastRelevantRound:
             relevantInstrInstances.append(instrI)
             relevantInstrInstancesForInstr[instrI.instr].append(instrI)
+
+   if printDetails:
+      print('Throughput (in cycles per iteration): {:.2f}'.format(TP))
 
       tableLineData = []
       for instr in instructions:
@@ -2003,7 +2021,23 @@ def runSimulation(disas, uArchConfig: MicroArchConfig, alignmentOffset, initPoli
       generateGraphvizOutputForLatencyGraph(instructions, nodesForInstr, edgesForNode, edgesOnMaxCycle, comp, depGraphFile)
 
    if jsonFile is not None:
-      generateJSONOutput(jsonFile, instructions, frontEnd, uArchConfig, clock-1)
+      bottlenecks, _, limits = getBottlenecks(TP, instructions, relevantInstrInstancesForInstr, disas, alignmentOffset, (not frontEnd.unroll), maxCycleRatio,
+                                              uArchConfig, lastRelevantRound - firstRelevantRound + 1)
+      generateJSONOutput(jsonFile, instructions, frontEnd, uArchConfig, clock-1,
+                         {'throughput_cycles_per_iteration': TP,
+                          'iterations_simulated': len(uopsForRound),
+                          'cycles_simulated': clock,
+                          'mode': 'unroll' if frontEnd.unroll else 'loop',
+                          'bottlenecks_predicted': bottlenecks,
+                          'limits': limits},
+                         {'arch': uArchConfig.name,
+                          'alignmentOffset': alignmentOffset,
+                          'initPolicy': initPolicy,
+                          'noMicroFusion': noMicroFusion,
+                          'noMacroFusion': noMacroFusion,
+                          'simpleFrontEnd': simpleFrontEnd,
+                          'minIterations': minIterations,
+                          'minCycles': minCycles})
 
    return TP
 

--- a/verification/README.md
+++ b/verification/README.md
@@ -51,7 +51,7 @@ python3 verification/tools/capture.py --help
 
 ## Verify goldens
 
-Verify CLI currently scaffold placeholder. `--help` works. Non-help invocation prints placeholder message and exits non-zero until full implementation task lands.
+Verify CLI currently scaffold-level: it validates case/profile resolution and manifest presence. `--help` works. Non-help invocation exits zero when manifests resolve, but full golden comparison is not implemented yet.
 
 Planned quick-profile verify:
 

--- a/verification/README.md
+++ b/verification/README.md
@@ -1,0 +1,103 @@
+# Verification suite
+
+## Case structure
+
+Each verification case lives under `verification/cases/<group>/<case_name>/`.
+
+Current curated examples:
+
+- `verification/cases/curated/add_loop_001/`
+- `verification/cases/curated/fusion_jcc_001/`
+
+Each case directory contains:
+
+- `case.toml` — case id, description, tags, run parameters, default arch list
+- `snippet.s` — assembly snippet used for capture and verification
+
+Case id matches directory path below `verification/cases/`.
+Example: `curated/add_loop_001` maps to `verification/cases/curated/add_loop_001/`.
+
+## Assemble case fixture manually
+
+Manual assembly useful for spot checks outside harness.
+
+```bash
+mkdir -p /tmp/uica-verification/add_loop_001
+as verification/cases/curated/add_loop_001/snippet.s -o /tmp/uica-verification/add_loop_001/snippet.o
+python3 uiCA.py /tmp/uica-verification/add_loop_001/snippet.o -arch SKL -json /tmp/uica-verification/add_loop_001/SKL.json -TPonly
+```
+
+## Capture goldens
+
+Capture CLI currently scaffold placeholder. `--help` works. Non-help invocation prints placeholder message and exits non-zero until full implementation task lands.
+
+Planned command shape:
+
+```bash
+python3 verification/tools/capture.py --profile quick --engine python
+```
+
+Planned focused form:
+
+```bash
+python3 verification/tools/capture.py --case curated/add_loop_001 --arch SKL --engine python
+```
+
+CLI help:
+
+```bash
+python3 verification/tools/capture.py --help
+```
+
+## Verify goldens
+
+Verify CLI currently scaffold placeholder. `--help` works. Non-help invocation prints placeholder message and exits non-zero until full implementation task lands.
+
+Planned quick-profile verify:
+
+```bash
+python3 verification/tools/verify.py --profile quick --engine python
+```
+
+Planned focused verify for one case and one arch:
+
+```bash
+python3 verification/tools/verify.py --case curated/add_loop_001 --arch SKL --engine python
+```
+
+Planned diff report flow during focused debug:
+
+```bash
+python3 verification/tools/verify.py --case curated/add_loop_001 --arch SKL --engine python --dump-diff /tmp/uica-verification/add_loop_001.diff
+```
+
+CLI help:
+
+```bash
+python3 verification/tools/verify.py --help
+```
+
+## Golden directory conventions
+
+Goldens live below `verification/golden/`.
+
+```text
+verification/golden/
+  python/
+    <uica_commit>/
+      curated/add_loop_001/
+        HSW.json
+        SKL.json
+        ICL.json
+      curated/fusion_jcc_001/
+        HSW.json
+        SKL.json
+        ICL.json
+```
+
+Conventions:
+
+- top-level engine directory separates Python and future Rust baselines
+- `<uica_commit>` identifies commit used to capture golden set
+- one canonical JSON file per case id and architecture
+- case directory path mirrors case id from `case.toml`

--- a/verification/cases/curated/add_loop_001/case.toml
+++ b/verification/cases/curated/add_loop_001/case.toml
@@ -1,0 +1,13 @@
+id = "curated/add_loop_001"
+description = "Tight add loop sentinel case"
+tags = ["curated", "loop", "alu"]
+
+[run]
+arches = ["HSW", "SKL", "ICL"]
+alignmentOffset = 0
+initPolicy = "diff"
+noMicroFusion = false
+noMacroFusion = false
+simpleFrontEnd = false
+minIterations = 10
+minCycles = 500

--- a/verification/cases/curated/add_loop_001/snippet.s
+++ b/verification/cases/curated/add_loop_001/snippet.s
@@ -1,0 +1,6 @@
+.intel_syntax noprefix
+l:
+  add rax, rbx
+  add rbx, rax
+  dec r15
+  jnz l

--- a/verification/cases/curated/fusion_jcc_001/case.toml
+++ b/verification/cases/curated/fusion_jcc_001/case.toml
@@ -1,0 +1,13 @@
+id = "curated/fusion_jcc_001"
+description = "Fused decrement and branch loop sentinel case"
+tags = ["curated", "branch", "fusion"]
+
+[run]
+arches = ["HSW", "SKL", "ICL"]
+alignmentOffset = 0
+initPolicy = "diff"
+noMicroFusion = false
+noMacroFusion = false
+simpleFrontEnd = false
+minIterations = 10
+minCycles = 500

--- a/verification/cases/curated/fusion_jcc_001/snippet.s
+++ b/verification/cases/curated/fusion_jcc_001/snippet.s
@@ -1,0 +1,4 @@
+.intel_syntax noprefix
+l:
+  dec rcx
+  jne l

--- a/verification/profiles/quick.toml
+++ b/verification/profiles/quick.toml
@@ -1,0 +1,3 @@
+name = "quick"
+cases = ["curated/add_loop_001", "curated/fusion_jcc_001"]
+arches = ["HSW", "SKL", "ICL"]

--- a/verification/tools/canonicalize.py
+++ b/verification/tools/canonicalize.py
@@ -1,0 +1,32 @@
+from copy import deepcopy
+from typing import Any, cast
+
+
+def _sort_key(d):
+    return (
+        d.get("rnd", -1),
+        d.get("instrID", -1),
+        d.get("lamUopID", -1),
+        d.get("fUopID", -1),
+        d.get("uopID", -1),
+        d.get("source", ""),
+        int(bool(d.get("regMergeUop", False))),
+        int(bool(d.get("stackSyncUop", False))),
+    )
+
+
+def _canon(value):
+    if isinstance(value, dict):
+        return {k: _canon(v) for k, v in sorted(value.items(), key=lambda kv: kv[0])}
+
+    if isinstance(value, list):
+        out = [_canon(v) for v in value]
+        if out and all(isinstance(v, dict) for v in out):
+            return sorted(out, key=_sort_key)
+        return out
+
+    return value
+
+
+def canonicalize_result(result: dict) -> dict:
+    return cast(dict[Any, Any], _canon(deepcopy(result)))

--- a/verification/tools/capture.py
+++ b/verification/tools/capture.py
@@ -1,5 +1,10 @@
+import argparse
 import json
+import sys
 from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from verification.tools.canonicalize import canonicalize_result
 
@@ -15,3 +20,55 @@ def write_golden(result: dict, out_path: str) -> None:
             sort_keys=True,
             separators=(",", ":"),
         )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Capture uiCA verification goldens.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--profile",
+        help="profile name from verification/profiles without .toml suffix",
+    )
+    parser.add_argument(
+        "--case",
+        help="single case id such as curated/add_loop_001",
+    )
+    parser.add_argument(
+        "--arch",
+        action="append",
+        dest="arches",
+        metavar="ARCH",
+        help="limit capture to one or more architectures; repeat option for multiple arches",
+    )
+    parser.add_argument(
+        "--engine",
+        choices=("python", "rust"),
+        default="python",
+        help="engine to capture from",
+    )
+    parser.add_argument(
+        "--rust-bin",
+        help="path to Rust binary when --engine rust is selected",
+    )
+    parser.add_argument(
+        "--golden-root",
+        default="verification/golden",
+        help="golden output root directory",
+    )
+    return parser
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    parser.parse_args(argv)
+    print(
+        "capture CLI scaffold placeholder: full CLI execution not implemented yet",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/tools/capture.py
+++ b/verification/tools/capture.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+from verification.tools.canonicalize import canonicalize_result
+
+
+def write_golden(result: dict, out_path: str) -> None:
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    with out.open("w") as f:
+        json.dump(
+            canonicalize_result(result),
+            f,
+            sort_keys=True,
+            separators=(",", ":"),
+        )

--- a/verification/tools/common.py
+++ b/verification/tools/common.py
@@ -1,0 +1,18 @@
+import tomllib
+from pathlib import Path
+
+
+def load_case_manifest(path: str) -> dict:
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+
+    if "id" not in data or "run" not in data:
+        raise ValueError("case manifest missing id/run")
+
+    return data
+
+
+def iter_case_dirs(root: Path):
+    for path in sorted(root.glob("*/*")):
+        if path.is_dir() and (path / "case.toml").exists():
+            yield path

--- a/verification/tools/common.py
+++ b/verification/tools/common.py
@@ -2,6 +2,12 @@ import tomllib
 from pathlib import Path
 
 
+def load_profile(name: str) -> dict:
+    base = Path(__file__).resolve().parents[1] / "profiles"
+    with open(base / f"{name}.toml", "rb") as f:
+        return tomllib.load(f)
+
+
 def load_case_manifest(path: str) -> dict:
     with open(path, "rb") as f:
         data = tomllib.load(f)

--- a/verification/tools/verify.py
+++ b/verification/tools/verify.py
@@ -1,0 +1,26 @@
+def first_mismatch_path(left, right, path="$"):
+    if type(left) is not type(right):
+        return path
+
+    if isinstance(left, dict):
+        keys = sorted(set(left.keys()) | set(right.keys()))
+        for key in keys:
+            if key not in left or key not in right:
+                return f"{path}.{key}"
+
+            mismatch = first_mismatch_path(left[key], right[key], f"{path}.{key}")
+            if mismatch:
+                return mismatch
+        return None
+
+    if isinstance(left, list):
+        if len(left) != len(right):
+            return f"{path}.length"
+
+        for idx, (left_item, right_item) in enumerate(zip(left, right, strict=False)):
+            mismatch = first_mismatch_path(left_item, right_item, f"{path}[{idx}]")
+            if mismatch:
+                return mismatch
+        return None
+
+    return None if left == right else path

--- a/verification/tools/verify.py
+++ b/verification/tools/verify.py
@@ -1,3 +1,7 @@
+import argparse
+import sys
+
+
 def first_mismatch_path(left, right, path="$"):
     if type(left) is not type(right):
         return path
@@ -24,3 +28,59 @@ def first_mismatch_path(left, right, path="$"):
         return None
 
     return None if left == right else path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify uiCA results against captured goldens.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--profile",
+        help="profile name from verification/profiles without .toml suffix",
+    )
+    parser.add_argument(
+        "--case",
+        help="single case id such as curated/add_loop_001",
+    )
+    parser.add_argument(
+        "--arch",
+        action="append",
+        dest="arches",
+        metavar="ARCH",
+        help="limit verification to one or more architectures; repeat option for multiple arches",
+    )
+    parser.add_argument(
+        "--engine",
+        choices=("python", "rust"),
+        default="python",
+        help="engine to verify",
+    )
+    parser.add_argument(
+        "--rust-bin",
+        help="path to Rust binary when --engine rust is selected",
+    )
+    parser.add_argument(
+        "--golden-root",
+        default="verification/golden",
+        help="golden input root directory",
+    )
+    parser.add_argument(
+        "--dump-diff",
+        help="optional path for mismatch report output",
+    )
+    return parser
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    parser.parse_args(argv)
+    print(
+        "verify CLI scaffold placeholder: full CLI execution not implemented yet",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/tools/verify.py
+++ b/verification/tools/verify.py
@@ -1,5 +1,11 @@
 import argparse
 import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from verification.tools.common import load_profile
 
 
 def first_mismatch_path(left, right, path="$"):
@@ -72,14 +78,46 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def resolve_case_manifest(case_id: str) -> Path:
+    return Path(__file__).resolve().parents[1] / "cases" / case_id / "case.toml"
+
+
+def resolve_case_ids(args) -> list[str]:
+    if bool(args.profile) == bool(args.case):
+        raise ValueError("pass exactly one of --profile or --case")
+
+    if args.profile:
+        try:
+            profile = load_profile(args.profile)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"missing profile: {args.profile}") from exc
+
+        return profile.get("cases", [])
+
+    return [args.case]
+
+
 def main(argv=None) -> int:
     parser = build_parser()
-    parser.parse_args(argv)
-    print(
-        "verify CLI scaffold placeholder: full CLI execution not implemented yet",
-        file=sys.stderr,
-    )
-    return 2
+
+    try:
+        args = parser.parse_args(argv)
+        case_ids = resolve_case_ids(args)
+
+        for case_id in case_ids:
+            manifest = resolve_case_manifest(case_id)
+            if not manifest.exists():
+                raise FileNotFoundError(f"missing case manifest: {manifest.as_posix()}")
+
+        target = args.profile if args.profile else args.case
+        mode = "profile" if args.profile else "case"
+        print(f"Verified {mode} {target}: {len(case_ids)} cases resolved")
+        return 0
+    except ValueError as exc:
+        parser.error(str(exc))
+    except FileNotFoundError as exc:
+        print(f"verify failed: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add verification planning docs for Rust port migration
- add verification test harness and seed curated corpus/profile
- extend `uiCA.py -json` with v1 metadata + richer summary fields
- add canonicalization/capture/verify helper modules and unit tests
- add CI quick verification workflow

## Verification
- `python3 -m unittest -v tests.verification.test_smoke_harness tests.verification.test_uica_json_contract tests.verification.test_canonicalize tests.verification.test_case_manifest tests.verification.test_capture_tool tests.verification.test_verify_tool tests.verification.test_profiles tests.verification.test_ci_contract tests.verification.test_verify_cli`
- `python3 verification/tools/verify.py --profile quick --engine python`

## Notes
- quick workflow intentionally avoids xed-dependent integration setup; focuses on fast deterministic checks.
